### PR TITLE
fix for the TSO EXECIO DISKW command in emitFile

### DIFF
--- a/dab.rex
+++ b/dab.rex
@@ -4003,7 +4003,7 @@ emitFile: procedure expose g.
     end
     when g.0ZOS & isDDName(sFile) then do /* DD:ddname */
       parse var sFile 'DD:'sDD .
-      address TSO 'EXECIO * DISKW' sDD '(FINIS'
+      address TSO 'EXECIO' queued() 'DISKW' sDD '(FINIS'
     end
     otherwise do
       hFile = openFile(sFile,'OUTPUT')


### PR DESCRIPTION
Had to replace the * with the queued() function to get EXECIO to write to the output DDname